### PR TITLE
command-line tool + directory sloc

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,12 @@ documentation: http://docs.racket-lang.org/syntax-sloc/index.html
 > (lang-file-sloc "lang-file-sloc.rkt")
 13
 ```
+
+On the command line, `raco sloc [<FILE-OR-DIRECTORY>] ...` prints line counts
+for its arguments.
+
+```
+$ raco sloc lang-file-sloc.rkt
+  SLOC  Source
+    13  lang-file-sloc.rkt
+```

--- a/directory-sloc.rkt
+++ b/directory-sloc.rkt
@@ -1,0 +1,11 @@
+#lang racket/base
+
+(provide directory-sloc)
+
+(require syntax-sloc/lang-file-sloc syntax-sloc/read-lang-file)
+
+;; directory-sloc : Path-String -> Natural
+(define (directory-sloc dir)
+  (for/sum ([src (in-directory dir)]
+            #:when (lang-file? src))
+    (lang-file-sloc src)))

--- a/info.rkt
+++ b/info.rkt
@@ -15,3 +15,6 @@
 
 (define scribblings '(["scribblings/syntax-sloc.scrbl" ()]))
 
+(define raco-commands '(
+  ("sloc" (submod syntax-sloc/raco-sloc main) "Count SLOC of a file or directory" #f)
+))

--- a/main.rkt
+++ b/main.rkt
@@ -1,3 +1,3 @@
 #lang racket/base
-(require "syntax-sloc.rkt" "lang-file-sloc.rkt")
-(provide (all-from-out "syntax-sloc.rkt" "lang-file-sloc.rkt"))
+(require "syntax-sloc.rkt" "lang-file-sloc.rkt" "directory-sloc.rkt")
+(provide (all-from-out "syntax-sloc.rkt" "lang-file-sloc.rkt" "directory-sloc.rkt"))

--- a/raco-sloc.rkt
+++ b/raco-sloc.rkt
@@ -1,0 +1,49 @@
+#lang racket/base
+
+;; Command-line interface for computing SLOC
+
+(require syntax-sloc
+         (only-in syntax-sloc/read-lang-file lang-file?)
+         racket/format)
+
+;; -----------------------------------------------------------------------------
+
+(define SLOC-HEADER "SLOC\tSource")
+
+(define MAX-PATH-WIDTH 40) ;; characters
+
+;; Get SLOC for `src`, output a string with pretty-printed results
+;; format-sloc : (Path-String -> Natural) Path-String -> String
+(define (format-sloc get-sloc src)
+  (string-append (~r (get-sloc src) #:min-width 4)
+                 "\t"
+                 (format-filepath src)))
+
+;; Print a filepath, truncate if too long
+;; format-filepath : Path-String -> String
+(define (format-filepath src)
+  (~a src #:max-width MAX-PATH-WIDTH
+          #:limit-marker "..."
+          #:limit-prefix? #t))
+
+;; missing-sloc : Path-String -> String
+(define (missing-sloc src)
+  (string-append " N/A" "\t" src))
+
+(module+ main
+  (require racket/cmdline)
+  (command-line
+   #:program "syntax-sloc"
+   ;; TODO optional arguments
+   #:args FILE-OR-DIRECTORY
+   (displayln SLOC-HEADER)
+   (for ([src (in-list FILE-OR-DIRECTORY)])
+     (displayln
+       (cond
+        [(directory-exists? src)
+         (format-sloc directory-sloc src)]
+        [(lang-file? src)
+         (format-sloc lang-file-sloc src)]
+        [else
+         (missing-sloc src)])))))
+

--- a/scribblings/syntax-sloc.scrbl
+++ b/scribblings/syntax-sloc.scrbl
@@ -49,3 +49,25 @@ a valid @hash-lang[] line or a racket @racket[module] form.
 (lang-file-sloc "lang-file-sloc.rkt")
 (lang-file-sloc "scribblings/syntax-sloc.scrbl")
 }}
+
+@section{Of a directory}
+
+@defmodule[syntax-sloc/directory-sloc]
+
+@defproc[(directory-sloc [path-string path-string?]) natural-number/c]{
+Counts the number of source lines of code in all @hash-lang[] files
+recursively contained inside the directory that @racket[path-string] points to.
+
+@code-examples[#:lang "racket" #:context #'here]{
+(require syntax-sloc)
+(current-directory (path-only (collection-file-path "lang-file-sloc.rkt" "syntax-sloc")))
+(directory-sloc (current-directory))
+}}
+
+@section{On the command line: @exec{raco sloc}}
+
+The @exec{raco sloc} command counts source lines of code in files or directories
+named on the command line and prints results.
+If an argument to @exec{raco sloc} is not a @hash-lang[] file or a directory,
+its line count is not computed.
+


### PR DESCRIPTION
- `raco sloc ...` counts lines of code in a file or directory
- `directory-sloc.rkt` implements the directory traversal (currently ignores dotfiles, we could extend this)

~~Also added a `.travis.yml` file, if we want to hook up with travis~~
