### PR TITLE
raco-sloc: filter search by #lang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 compiled/
 doc/
 *~
+*.swp
+*.swo

--- a/syntax-sloc/raco-sloc.rkt
+++ b/syntax-sloc/raco-sloc.rkt
@@ -4,7 +4,10 @@
 
 (require syntax-sloc
          (only-in syntax-sloc/read-lang-file lang-file?)
-         racket/format)
+         (only-in racket/list last)
+         (only-in racket/string string-trim)
+         (only-in racket/port call-with-input-string peeking-input-port)
+         (only-in racket/format ~a ~r))
 
 ;; -----------------------------------------------------------------------------
 
@@ -30,20 +33,115 @@
 (define (missing-sloc src)
   (string-append " N/A" "\t" src))
 
+;; lang-line-match : Pregexp -> Path-String -> Boolean
+(define (lang-line-match? px src)
+  (define lang-line (call-with-input-file src read-#lang))
+  (and lang-line (regexp-match-exact? px lang-line)))
+
+;; read-#lang : Input-Port -> (U #f String)
+(define (read-#lang port)
+  (define end-pos
+    (let* ([lang-in (peeking-input-port port)])
+      (and (procedure? (with-handlers ([exn:fail? (lambda (e) #f)])
+                         (read-language lang-in)))
+           (file-position lang-in))))
+  (define str (and end-pos (read-string end-pos (peeking-input-port port))))
+  (define lang-posn* (and (string? str) (regexp-match-positions* "#lang|#!" str)))
+  (and lang-posn*
+       (string-trim (substring str (cdr (last lang-posn*))))))
+
 (module+ main
   (require racket/cmdline)
+  (define *lang-file-pregexp* (make-parameter #f))
   (command-line
    #:program "syntax-sloc"
-   ;; TODO optional arguments
+   #:once-each
+   [("-l" "--lang")
+    lang-pregexp
+    "Only count files with a matching #lang line"
+    (*lang-file-pregexp* (pregexp lang-pregexp))]
    #:args FILE-OR-DIRECTORY
    (displayln SLOC-HEADER)
+   (define matching-lang? ;; : Path-String -> Boolean
+     (let ([px (*lang-file-pregexp*)])
+       (if px
+         (lambda (src) (lang-line-match? px (if (path? src) (path->string src) src)))
+         (lambda (src) #t))))
+   (define (directory-sloc/filter src)
+     (directory-sloc src #:use-file? matching-lang?))
    (for ([src (in-list FILE-OR-DIRECTORY)])
      (displayln
        (cond
         [(directory-exists? src)
-         (format-sloc directory-sloc src)]
-        [(lang-file? src)
+         (format-sloc directory-sloc/filter src)]
+        [(and (lang-file? src) (matching-lang? src))
          (format-sloc lang-file-sloc src)]
         [else
          (missing-sloc src)])))))
 
+(module+ test
+  (require rackunit)
+
+  (define (read-#lang-from-strings . str*)
+    (call-with-input-string (apply string-append str*) read-#lang))
+
+  ;; -- basic #langs
+  (check-equal?
+    (read-#lang-from-strings
+      "#lang racket/base\n"
+      "(+ 1 2")
+    "racket/base")
+  (check-equal?
+    (read-#lang-from-strings
+      "#lang racket/base\n"
+      "(+ 1 2)")
+    "racket/base")
+  (check-equal?
+    (read-#lang-from-strings
+      "\n\n#lang racket\n")
+    "racket")
+  (check-equal?
+    (read-#lang-from-strings
+      "#lang scribble/manual\n"
+      "some text for scribble\n")
+    "scribble/manual")
+  (check-equal?
+    (read-#lang-from-strings
+      "   #lang typed/racket")
+    "typed/racket")
+
+  ;; -- confusing #langs
+  (check-equal?
+    (read-#lang-from-strings
+      "#!racket")
+    "racket")
+  (check-equal?
+    (read-#lang-from-strings
+      ";; extra comment\n"
+      "#lang racket/base \n"
+      "(+ 1 2)")
+    "racket/base")
+  (check-equal?
+    (read-#lang-from-strings
+      "#| another kind of comment \n"
+      "|#\n"
+      "#lang scribble/html")
+    "scribble/html")
+  (check-equal?
+    (read-#lang-from-strings
+      "#lang at-exp racket")
+    "at-exp racket")
+  (check-equal?
+    (read-#lang-from-strings
+      "#|#lang scribble/manual|# #!racket")
+    "racket")
+
+   ;; -- failures
+  (check-false
+    (read-#lang-from-strings
+      "#lang #| bad comment |# racket"))
+  (check-false
+    (read-#lang-from-strings
+      "#lang     racket\n"
+      ";; has too many spaces\n"))
+)

--- a/syntax-sloc/scribblings/syntax-sloc.scrbl
+++ b/syntax-sloc/scribblings/syntax-sloc.scrbl
@@ -1,6 +1,7 @@
 #lang scribble/manual
 
 @(require scribble-code-examples
+          (only-in scribble/bnf nonterm)
           (for-label racket/base
                      racket/contract/base
                      racket/path
@@ -81,3 +82,13 @@ named on the command line and prints results.
 If an argument to @exec{raco sloc} is not a @hash-lang[] file or a directory,
 its line count is not computed.
 
+Available flags:
+@itemlist[
+  @item{
+    @DFlag{lang} @nonterm{lang-pregexp} --- Only count lines for files whose
+      @hash-lang[] string exactly matches the @nonterm{lang-pregexp} regular
+      expression.
+      For example @DFlag{lang} @tt{racket} will match @tt{#lang racket} and
+      @tt{#!racket} but not @tt{#lang racket/base} or @tt{#lang sweet-exp racket}.
+  }
+]


### PR DESCRIPTION
Add `--lang <PREGEXP>` command line option to limit search to files whose `#lang` matches the regular expression.

"Works", but:
- ~~manually parses the `#lang` line from a path string~~
- uses pregexp because I think most users will be through posix-compliant terminals
- ~~no tests; should we make a repo `syntax-sloc-test` with static files to count lines for?~~
- looks for exact matches (so "racket" doesn't capture "racket/base" files)

~~Will write docs once we agree on a design.~~

Examples:

```
bash-3.2$ raco sloc .
SLOC    Source
  399   .
bash-3.2$ raco sloc --lang racket .
SLOC    Source
   0    .
bash-3.2$ raco sloc --lang racket/base .
SLOC    Source
 169    .
bash-3.2$ raco sloc --lang "scribble.*" *
SLOC    Source
 N/A    README.md
   0    compiled
   0    info.rkt
   0    scribblings
  93    syntax-sloc
   0    typed
```
