### PR TITLE
[WIP] filter line counts by module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ documentation: http://docs.racket-lang.org/syntax-sloc/index.html
 ; or counting them in a #lang file:
 > (current-directory (path-only (collection-file-path "lang-file-sloc.rkt" "syntax-sloc")))
 > (lang-file-sloc "lang-file-sloc.rkt")
-14
+29
 ```
 
 On the command line, `raco sloc [<FILE-OR-DIRECTORY>] ...` prints line counts
@@ -27,5 +27,5 @@ for its arguments.
 ```
 $ raco sloc lang-file-sloc.rkt
   SLOC  Source
-    14  lang-file-sloc.rkt
+    29  lang-file-sloc.rkt
 ```

--- a/syntax-sloc/directory-sloc.rkt
+++ b/syntax-sloc/directory-sloc.rkt
@@ -6,8 +6,8 @@
          typed/syntax-sloc/read-lang-file
          syntax-sloc/syntax-sloc)
 
-(: directory-sloc : Path-String [#:use-file? (Path -> Boolean)] [#:use-stx? Stx-Pred] -> Natural)
-(define (directory-sloc dir #:use-file? [use-file? (λ (path) #t)] #:use-stx? [use-stx? #f])
+(: directory-sloc : Path-String [#:use-file? (Path -> Boolean)] [#:include-stx? Stx-Pred] -> Natural)
+(define (directory-sloc dir #:use-file? [use-file? (λ (path) #t)] #:include-stx? [include-stx? #f])
   (for/sum ([src (in-directory dir)]
             #:when (and (file-exists? src) (use-file? src) (lang-file? src))) : Natural
-    (lang-file-sloc src #:use-stx? use-stx?)))
+    (lang-file-sloc src #:include-stx? include-stx?)))

--- a/syntax-sloc/directory-sloc.rkt
+++ b/syntax-sloc/directory-sloc.rkt
@@ -2,10 +2,12 @@
 
 (provide directory-sloc)
 
-(require syntax-sloc/lang-file-sloc typed/syntax-sloc/read-lang-file)
+(require syntax-sloc/lang-file-sloc
+         typed/syntax-sloc/read-lang-file
+         syntax-sloc/syntax-sloc)
 
-(: directory-sloc : Path-String [#:use-file? (Path -> Boolean)] -> Natural)
-(define (directory-sloc dir #:use-file? [use-file? (λ (path) #t)])
+(: directory-sloc : Path-String [#:use-file? (Path -> Boolean)] [#:use-stx? Stx-Pred] -> Natural)
+(define (directory-sloc dir #:use-file? [use-file? (λ (path) #t)] #:use-stx? [use-stx? #f])
   (for/sum ([src (in-directory dir)]
             #:when (and (file-exists? src) (use-file? src) (lang-file? src))) : Natural
-    (lang-file-sloc src)))
+    (lang-file-sloc src #:use-stx? use-stx?)))

--- a/syntax-sloc/lang-file-sloc.rkt
+++ b/syntax-sloc/lang-file-sloc.rkt
@@ -6,20 +6,36 @@
 
 (provide lang-file-sloc)
 
-(require "syntax-sloc.rkt"
-         typed/syntax-sloc/read-lang-file
-         syntax-sloc/syntax-sloc)
+(require racket/set
+         syntax-sloc/syntax-sloc
+         typed/syntax-sloc/read-lang-file)
 
 (module+ test
   (require typed/rackunit
            racket/runtime-path))
 
-(: lang-file-sloc : Path-String [#:use-stx? Stx-Pred] -> Natural)
-(define (lang-file-sloc path-string #:use-stx? [use-stx? #f])
-  (syntax-sloc (read-lang-file path-string) #:use-stx? use-stx?))
+(: lang-file-sloc : Path-String [#:include-stx? Stx-Pred] -> Natural)
+(define (lang-file-sloc path-string #:include-stx? [include-stx? #f])
+  (define raw-stx (read-lang-file path-string))
+  (define the-src (syntax-source raw-stx))
+  (define exp-stx
+    (parameterize ([current-namespace (make-base-namespace)])
+      (expand raw-stx)))
+  (define stx-to-count
+    (if include-stx?
+      (filter/stx exp-stx include-stx?)
+      (list exp-stx)))
+  (define (id/the-src? (stx : (Syntaxof Any))) : Boolean
+    (and (identifier? stx) (equal? the-src (syntax-source stx))))
+  (define lines-from-identifiers
+    (for/fold : (Setof Natural)
+              ([acc : (Setof Natural) (set)])
+              ([stx (in-list stx-to-count)])
+      (source-lines/filter stx id/the-src? acc)))
+  (set-count lines-from-identifiers))
 
 (module+ test
   (define-runtime-path this-file "lang-file-sloc.rkt")
   (check-equal? (lang-file-sloc this-file)
-                14))
+                29))
 

--- a/syntax-sloc/lang-file-sloc.rkt
+++ b/syntax-sloc/lang-file-sloc.rkt
@@ -7,15 +7,16 @@
 (provide lang-file-sloc)
 
 (require "syntax-sloc.rkt"
-         typed/syntax-sloc/read-lang-file)
+         typed/syntax-sloc/read-lang-file
+         syntax-sloc/syntax-sloc)
 
 (module+ test
   (require typed/rackunit
            racket/runtime-path))
 
-(: lang-file-sloc : Path-String -> Natural)
-(define (lang-file-sloc path-string)
-  (syntax-sloc (read-lang-file path-string)))
+(: lang-file-sloc : Path-String [#:use-stx? Stx-Pred] -> Natural)
+(define (lang-file-sloc path-string #:use-stx? [use-stx? #f])
+  (syntax-sloc (read-lang-file path-string) #:use-stx? use-stx?))
 
 (module+ test
   (define-runtime-path this-file "lang-file-sloc.rkt")

--- a/syntax-sloc/main.rkt
+++ b/syntax-sloc/main.rkt
@@ -1,3 +1,5 @@
 #lang racket/base
-(require "syntax-sloc.rkt" "lang-file-sloc.rkt" "directory-sloc.rkt")
-(provide (all-from-out "syntax-sloc.rkt" "lang-file-sloc.rkt" "directory-sloc.rkt"))
+(require "syntax-sloc.rkt" "lang-file-sloc.rkt" "directory-sloc.rkt"
+         "syntax-predicates.rkt")
+(provide (all-from-out "syntax-sloc.rkt" "lang-file-sloc.rkt" "directory-sloc.rkt"
+                       "syntax-predicates.rkt"))

--- a/syntax-sloc/raco-sloc.rkt
+++ b/syntax-sloc/raco-sloc.rkt
@@ -1,67 +1,137 @@
-#lang racket/base
+#lang typed/racket/base
 
 ;; Command-line interface for computing SLOC
 
 (require syntax-sloc
-         (only-in syntax-sloc/read-lang-file lang-file? lang-file-lang)
+         (only-in typed/syntax-sloc/read-lang-file lang-file? lang-file-lang)
+         (only-in racket/port with-input-from-string)
+         (only-in racket/string string-join string-prefix? string-suffix?)
          (only-in racket/format ~a ~r))
 
 ;; -----------------------------------------------------------------------------
 
-(define SLOC-HEADER "SLOC\tSource")
+(define SLOC-HEADER "SLOC~a\tSource")
 
 (define MAX-PATH-WIDTH 40) ;; characters
 
 ;; Get SLOC for `src`, output a string with pretty-printed results
-;; format-sloc : (Path-String -> Natural) Path-String -> String
+(: format-sloc : (Path-String -> Natural) Path-String -> String)
 (define (format-sloc get-sloc src)
   (string-append (~r (get-sloc src) #:min-width 4)
                  "\t"
                  (format-filepath src)))
 
 ;; Print a filepath, truncate if too long
-;; format-filepath : Path-String -> String
+(: format-filepath : Path-String -> String)
 (define (format-filepath src)
   (~a src #:max-width MAX-PATH-WIDTH
           #:limit-marker "..."
           #:limit-prefix? #t))
 
-;; missing-sloc : String -> String
+(: missing-sloc : String -> String)
 (define (missing-sloc src)
   (string-append " N/A" "\t" src))
 
-;; lang-line-match? : Pregexp Path-String -> Boolean
+(: lang-line-match? : Regexp Path-String -> Boolean)
 (define (lang-line-match? px src)
   (define lang-line (lang-file-lang src))
   (and lang-line (regexp-match-exact? px lang-line)))
 
+;; -----------------------------------------------------------------------------
+
+(: module-option-help : (Listof (U (List Symbol String) (List Symbol String Stx-Pred))))
+(define module-option-help
+`(
+  (contract
+   "racket/contract contract values"
+   ,is-contract?)
+  (type-ann
+   "Typed Racket type annotations"
+   ,is-type-ann?)
+  (<module-path>
+   "Lines with identifiers provided by <module-path>")
+  (listof-<module-path>
+   "Lines with identifiers provided by any module in the list")
+))
+
+(: string->stx-pred : String -> Stx-Pred)
+(define (string->stx-pred str)
+  (define sym (string->symbol str))
+  (define builtin-pred
+    (for/or : Stx-Pred
+            ([sym+desc (in-list module-option-help)]
+             #:when (and (eq? sym (car sym+desc))
+                         (not (null? (cddr sym+desc)))))
+      (caddr sym+desc)))
+  (cond
+   [builtin-pred
+    builtin-pred]
+   [(module-path? sym)
+    (module-path->stx-predicate sym)]
+   [(and (string-prefix? str "(") (string-suffix? str ")"))
+    (with-handlers ([exn:fail? (lambda (exn) #f)])
+      (define val (cast (with-input-from-string str read) (Listof Module-Path)))
+      (module-path*->stx-predicate val))]
+   [else
+    #f]))
+
+(: string->stx-pred/fail : String -> Stx-Pred)
+(define (string->stx-pred/fail str)
+  (or (string->stx-pred str)
+      (raise-user-error 'raco-sloc "Unrecognized module '~a'." str)))
+
+;; Format the current syntax object filter for console output.
+;; (Will go in the header for the "~a" in "SLOC~a")
+(: module-path-string->header : (U #f String) -> String)
+(define (module-path-string->header s)
+  (if s (format "(~a)" s) ""))
+
+;; -----------------------------------------------------------------------------
 
 (module+ main
   (require racket/cmdline)
-  (define *lang-file-pregexp* (make-parameter #f))
+  (define *lang-file-pregexp* : (Parameterof (U #f Regexp)) (make-parameter #f))
+  (define *mp-string*         : (Parameterof (U #f String)) (make-parameter #f))
+  (define *use-stx?*          : (Parameterof Stx-Pred) (make-parameter #f))
   (command-line
    #:program "syntax-sloc"
    #:once-each
    [("-l" "--lang")
     lang-pregexp
     "Only count files with a matching #lang line"
-    (*lang-file-pregexp* (pregexp lang-pregexp))]
+    (*lang-file-pregexp* (pregexp (assert lang-pregexp string?)))]
+   [("-m" "--module")
+    mp
+    [(string-join
+      (cons (format "One of ~a. Only count lines from matching syntax objects, defined as:\n" (map (inst car Symbol Any) module-option-help))
+            (for/list : (Listof String) ([sym+desc (in-list module-option-help)])
+              (~a "  - " (car sym+desc) " : " (cadr sym+desc))))
+      "\n")]
+    (let ([mp-str (assert mp string?)])
+      (*use-stx?* (string->stx-pred/fail mp-str))
+      (*mp-string* mp-str))]
    #:args FILE-OR-DIRECTORY
    (define px (*lang-file-pregexp*))
-   (displayln SLOC-HEADER)
-   (define matching-lang? ;; : Path-String -> Boolean
+   (printf SLOC-HEADER (module-path-string->header (*mp-string*)))
+   (newline)
+   (define matching-lang? : (-> Path-String Boolean)
      (if px
-         (lambda (src) (lang-line-match? px src))
-         (lambda (src) #t)))
-   (define (directory-sloc/filter src)
-     (directory-sloc src #:use-file? matching-lang?))
-   (for ([src (in-list FILE-OR-DIRECTORY)])
+         (lambda ((src : Path-String)) (lang-line-match? px src))
+         (lambda ((src : Path-String)) #t)))
+   (define use-stx? : Stx-Pred
+     (*use-stx?*))
+   (define (directory-sloc/filter (src : Path-String)) : Natural
+     (directory-sloc src #:use-file? matching-lang? #:use-stx? use-stx?))
+   (define (lang-file-sloc/filter (src : Path-String)) : Natural
+     (lang-file-sloc src #:use-stx? use-stx?))
+   (for ([any (in-list FILE-OR-DIRECTORY)])
+     (define src (assert any string?))
      (displayln
        (cond
         [(directory-exists? src)
          (format-sloc directory-sloc/filter src)]
         [(and (lang-file? src) (matching-lang? src))
-         (format-sloc lang-file-sloc src)]
+         (format-sloc lang-file-sloc/filter src)]
         [else
          (missing-sloc src)])))))
 

--- a/syntax-sloc/scribblings/syntax-sloc.scrbl
+++ b/syntax-sloc/scribblings/syntax-sloc.scrbl
@@ -97,9 +97,10 @@ Available flags:
 @itemlist[
   @item{
     @DFlag{module} @nonterm{module-path} --- Only count lines containing
-      identifiers from the module (or list of modules) @nonterm{module-path}.
+      identifiers from the module @nonterm{module-path}.
       For instance, @exec{raco sloc --module racket/string *.rkt} counts only
        lines using identifiers from @racket[racket/string].
+      Any number of @exec{--module} flags can be passed to a single command.
 
       Certain symbols represent a pre-defined group of module paths e.g.
        @exec{raco sloc --module type-ann *.rkt} will approximate the number of

--- a/syntax-sloc/scribblings/syntax-sloc.scrbl
+++ b/syntax-sloc/scribblings/syntax-sloc.scrbl
@@ -18,12 +18,17 @@ source code: @url{https://github.com/AlexKnauth/syntax-sloc}
 
 @defmodule[syntax-sloc/syntax-sloc]
 
-@defproc[(syntax-sloc [stx syntax?]) natural-number/c]{
+@defproc[(syntax-sloc [stx syntax?]
+                      [#:use-stx? use-stx? (or/c #f (-> syntax? boolean?) #f)])
+         natural-number/c]{
 Counts the number of source lines of code in the syntax object
 @racket[stx], not counting whitespace or comments.
+If @racket[use-stx?] is a procedure, the count is only for syntax objects
+that @racket[use-stx?] returns @racket[#t] for.
 
-It does this by going through every syntax object within it, including
-every sub-expression, looking at the @racket[syntax-line] of each one,
+Line counts are computed by going through every syntax object within @racket[stx],
+including every sub-expression, looking at the @racket[syntax-line] of each one
+(that @racket[use-stx?] does not return @racket[#f] for),
 and counting how many different lines are there.
 
 @code-examples[#:lang "racket/base" #:context #'here]{
@@ -39,10 +44,14 @@ and counting how many different lines are there.
 
 @defmodule[syntax-sloc/lang-file-sloc]
 
-@defproc[(lang-file-sloc [path-string path-string?]) natural-number/c]{
+@defproc[(lang-file-sloc [path-string path-string?]
+                         [#:use-stx? use-stx? (or/c #f (-> syntax? boolean?) #f)])
+         natural-number/c]{
 Counts the number of source lines of code in the file that
 @racket[path-string] points to. This file must start with either
-a valid @hash-lang[] line or a racket @racket[module] form. 
+a valid @hash-lang[] line or a racket @racket[module] form.
+Use @racket[use-stx?] is not @racket[#f], the count excludes lines from syntax
+objects that @racket[use-stx?} returns @racket[#f] for.
 
 @code-examples[#:lang "racket" #:context #'here]{
 (require syntax-sloc)
@@ -56,11 +65,13 @@ a valid @hash-lang[] line or a racket @racket[module] form.
 @defmodule[syntax-sloc/directory-sloc]
 
 @defproc[(directory-sloc [path-string path-string?]
-                         [#:use-file? use-file? (-> path? boolean?) (λ (path) #t)])
+                         [#:use-file? use-file? (-> path? boolean?) (λ (path) #t)]
+                         [#:use-stx? use-stx? (or/c #f (-> syntax? boolean?) #f)])
          natural-number/c]{
 Counts the number of source lines of code in all @hash-lang[] files
 recursively contained inside the directory that @racket[path-string] points to,
-except for the ones that @racket[use-file?] returns false for.
+except for files that @racket[use-file?] returns false for and syntax objects
+that @racket[use-stx?] returns false for.
 
 @code-examples[#:lang "racket" #:context #'here]{
 (require syntax-sloc)
@@ -84,6 +95,17 @@ its line count is not computed.
 
 Available flags:
 @itemlist[
+  @item{
+    @DFlag{module} @nonterm{module-path} --- Only count lines containing
+      identifiers from the module (or list of modules) @nonterm{module-path}.
+      For instance, @exec{raco sloc --module racket/string *.rkt} counts only
+       lines using identifiers from @racket[racket/string].
+
+      Certain symbols represent a pre-defined group of module paths e.g.
+       @exec{raco sloc --module type-ann *.rkt} will approximate the number of
+       type annotations in files.
+      Use @exec{raco sloc --help} for more info.
+  }
   @item{
     @DFlag{lang} @nonterm{lang-pregexp} --- Only count lines for files whose
       @hash-lang[] string exactly matches the @nonterm{lang-pregexp} regular

--- a/syntax-sloc/syntax-predicates.rkt
+++ b/syntax-sloc/syntax-predicates.rkt
@@ -1,0 +1,97 @@
+#lang typed/racket/base
+
+(provide module-path*->stx-predicate
+         module-path->stx-predicate
+         is-type-ann?
+         is-contract?)
+
+(require racket/set
+         syntax-sloc/syntax-sloc)
+
+(require/typed syntax/id-set
+  (#:opaque Free-Id-Set immutable-free-id-set?)
+  (immutable-free-id-set (->* [] [(Listof Identifier)] Free-Id-Set))
+  (free-id-set-add (-> Free-Id-Set Identifier Free-Id-Set))
+  (free-id-set->list (-> Free-Id-Set (Listof Identifier)))
+  (free-id-set-member? (-> Free-Id-Set Identifier Boolean))
+  (free-id-set-for-each (-> Free-Id-Set (-> Identifier Void) Void))
+  (free-id-set-union (-> Free-Id-Set Free-Id-Set Free-Id-Set))
+)
+
+(require/typed syntax/modresolve
+  (resolve-module-path (-> Module-Path Path)))
+
+(module+ test
+  (require typed/rackunit))
+
+(: module-path*->stx-predicate (-> (Listof Module-Path) Stx-Pred))
+(define (module-path*->stx-predicate mp*)
+  (define p* (map module-path->stx-predicate mp*))
+  (lambda ([stx : (Syntaxof Any)])
+    (for/or ([p (in-list p*)]) : Boolean
+      (and p (p stx)))))
+
+(: module-path->stx-predicate (-> Module-Path Stx-Pred))
+(define (module-path->stx-predicate mp)
+  (define id* (module-path->id-set mp))
+  (lambda ([stx : (Syntaxof Any)])
+    (and (identifier? stx)
+         (free-id-set-member? id* stx)
+         ;(printf "YES ~a\n" stx)
+         #t)))
+
+(: module-path->id-set (-> Module-Path Free-Id-Set))
+(define (module-path->id-set mp)
+  (define r (resolve-module-path mp))
+  (parameterize ([current-namespace (make-base-namespace)])
+    (dynamic-require r (void))
+    (define-values (var* stx*) (module->exports r))
+    (free-id-set-union
+      (provided->id-set var*)
+      (provided->id-set stx*))))
+
+(define-type RawProvided (Pairof Phase (Listof (List Symbol History))))
+(define-type Phase       (U #f Integer))
+(define-type History     (Listof Any)) ;; Lazy
+
+;; Uses `current-namespace` to get identifiers from symbols
+(: provided->id-set (-> (Listof RawProvided) Free-Id-Set))
+(define (provided->id-set provided**)
+  (for/fold : Free-Id-Set
+            ([acc : Free-Id-Set (immutable-free-id-set)])
+            ([phase+p* (in-list provided**)])
+    ;; ignore Phase and History
+    (for/fold ([acc acc])
+              ([sym+hist (in-list (cdr phase+p*))])
+      (free-id-set-add acc (namespace-syntax-introduce #`#,(car sym+hist))))))
+
+;; TODO doc (only the flat ids)
+(: syntax->shallow-id-set (-> (Syntaxof Any) Free-Id-Set))
+(define (syntax->shallow-id-set stx)
+  (define e (syntax-e stx))
+  (cond
+   [(symbol? e)
+    (immutable-free-id-set (list stx))]
+   [(list? e)
+    (immutable-free-id-set (filter identifier? e))]
+   [else
+    (immutable-free-id-set)]))
+
+;; -----------------------------------------------------------------------------
+
+(: is-type-ann? Stx-Pred)
+(define is-type-ann?
+  (module-path->stx-predicate 'typed-racket/base-env/base-types))
+
+(: is-contract? Stx-Pred)
+(define is-contract?
+  (module-path->stx-predicate 'racket/contract))
+
+;; =============================================================================
+
+(module+ test
+  ;; -- module-path->stx-predicate
+  ;; -- module-path->symbol*
+  ;; -- provided->symbol*
+  ;; -- syntax->shallow-id-set
+)

--- a/syntax-sloc/syntax-sloc.rkt
+++ b/syntax-sloc/syntax-sloc.rkt
@@ -1,6 +1,8 @@
 #lang typed/racket/base
 
 (provide syntax-sloc
+         filter/stx
+         source-lines/filter
          Stx-Pred)
 
 (require racket/set
@@ -12,6 +14,10 @@
            (submod "private/accumulate-stx.rkt" test)))
 
 (define-type Stx-Pred (U #f (-> (Syntaxof Any) Boolean)))
+
+(: syntax-sloc : (Syntaxof Any) -> Natural)
+(define (syntax-sloc stx)
+  (set-count (source-lines stx (set))))
 
 (: syntax-sloc/filter : (Syntaxof Any) [(Syntaxof Any) -> Boolean] -> Natural)
 (define (syntax-sloc/filter stx include-stx?)

--- a/syntax-sloc/syntax-sloc.rkt
+++ b/syntax-sloc/syntax-sloc.rkt
@@ -1,6 +1,7 @@
 #lang typed/racket/base
 
-(provide syntax-sloc)
+(provide syntax-sloc
+         Stx-Pred)
 
 (require racket/set
          "private/accumulate-stx.rkt"
@@ -10,9 +11,7 @@
   (require typed/rackunit typed/syntax/stx
            (submod "private/accumulate-stx.rkt" test)))
 
-(: syntax-sloc : (Syntaxof Any) -> Natural)
-(define (syntax-sloc stx)
-  (set-count (source-lines stx (set))))
+(define-type Stx-Pred (U #f (-> (Syntaxof Any) Boolean)))
 
 (: syntax-sloc/filter : (Syntaxof Any) [(Syntaxof Any) -> Boolean] -> Natural)
 (define (syntax-sloc/filter stx include-stx?)

--- a/test/data/README.md
+++ b/test/data/README.md
@@ -1,0 +1,10 @@
+data
+====
+
+Data files for unit testing.
+
+Each line of code in the examples is hand-annotated with a `#|   |#` comment at
+ the beginning of the line.
+Characters within the comment are checked against tags in `test/main.rkt`,
+ so we can match expected counts against actual counts.
+

--- a/test/data/contract/redefine.rkt
+++ b/test/data/contract/redefine.rkt
@@ -2,4 +2,4 @@
 
 #| C    |# (define Integer 1)
 #| C    |# (define -> (lambda (x y) x))
-#| C    |# (define (-> Integer Integer))
+#| C    |# (define r (-> Integer Integer))

--- a/test/data/contract/redefine.rkt
+++ b/test/data/contract/redefine.rkt
@@ -1,0 +1,5 @@
+#lang racket/base
+
+#| C    |# (define Integer 1)
+#| C    |# (define -> (lambda (x y) x))
+#| C    |# (define (-> Integer Integer))

--- a/test/data/contract/rename-in.rkt
+++ b/test/data/contract/rename-in.rkt
@@ -1,0 +1,13 @@
+#lang racket/base
+#| C    |# (require
+#|      |#   (prefix-in c: (only-in racket/contract ->))
+#|      |#   (rename-in racket/contract [natural-number/c nat/c]))
+
+#| C    |# (define nat?
+#|    R |#   nat/c)
+#| C    |# (define/contract foo
+#|    R |#   (c:->
+#|    R |#     nat/c
+#|    R |#     nat/c)
+#| C    |#   (lambda (x) 3))
+

--- a/test/data/contract/simple.rkt
+++ b/test/data/contract/simple.rkt
@@ -1,0 +1,12 @@
+#lang racket
+
+#| C R |# (define/contract x
+#| C   |#   integer?
+#| C   |#   1)
+
+#| C   |# (define (y z)
+#| C   |#   z)
+
+#| C   |# (provide
+#|   R |#   (contract-out
+#|   R |#     [y (-> natural-number/c natural-number/c)]))

--- a/test/data/contract/submodule.rkt
+++ b/test/data/contract/submodule.rkt
@@ -1,9 +1,9 @@
 #lang racket/base
 
-#| C    |# (module a
+#| C    |# (module a racket/base
 #| C    |#   (require racket/contract)
 #| C  R |#   (define/contract x integer? 2))
 #|      |#
-#| C    |# (module* b
+#| C    |# (module* b racket/base
 #| C    |#   (require racket/contract)
 #| C  R |#   (define/contract y integer? 3))

--- a/test/data/contract/submodule.rkt
+++ b/test/data/contract/submodule.rkt
@@ -1,0 +1,9 @@
+#lang racket/base
+
+#| C    |# (module a
+#| C    |#   (require racket/contract)
+#| C  R |#   (define/contract x integer? 2))
+#|      |#
+#| C    |# (module* b
+#| C    |#   (require racket/contract)
+#| C  R |#   (define/contract y integer? 3))

--- a/test/data/contract/url.rkt
+++ b/test/data/contract/url.rkt
@@ -1,0 +1,507 @@
+#lang racket/base
+#| C    |# (require racket/port
+#| C    |#          racket/string
+#| C    |#          racket/contract/base
+#| C    |#          racket/list
+#| C    |#          racket/match
+#| C    |#          racket/promise
+#| C    |#          (prefix-in hc: net/http-client)
+#| C    |#          (only-in net/url-connect current-https-protocol)
+#| C    |#          net/uri-codec
+#| C    |#          net/url-string
+#| C    |#          (only-in net/url-exception make-url-exception))
+
+#| C    |# ;; To do:
+#| C    |# ;;   Handle HTTP/file errors.
+#| C    |# ;;   Not throw away MIME headers.
+#| C    |# ;;     Determine file type.
+
+#| C    |# (define-logger net/url)
+
+#| C    |# ;; ----------------------------------------------------------------------
+
+#| C    |# ;; Input ports have two statuses:
+#| C    |# ;;   "impure" = they have text waiting
+#| C    |# ;;   "pure" = the MIME headers have been read
+
+#| C    |# (define proxiable-url-schemes '("http"))
+
+#| C    |# (define (env->c-p-s-entries envars)
+#| C    |#   (if (null? envars)
+#| C    |#       null
+#| C    |#       (match (getenv (car envars))
+#| C    |#         [#f (env->c-p-s-entries (cdr envars))]
+#| C    |#         ["" null]
+#| C    |#         [(app string->url
+#| C    |#               (url (and scheme "http") #f (? string? host) (? integer? port)
+#| C    |#                    _ (list) (list) #f))
+#| C    |#          (list (list scheme host port))]
+#| C    |#         [(app string->url
+#| C    |#               (url (and scheme "http") _ (? string? host) (? integer? port)
+#| C    |#                    _ _ _ _))
+#| C    |#          (log-net/url-error "~s contains somewhat invalid proxy URL format" (car envars))
+#| C    |#          (list (list scheme host port))]
+#| C    |#         [inv (log-net/url-error "~s contained invalid proxy URL format: ~s"
+#| C    |#                                 (car envars) inv)
+#| C    |#              null])))
+
+#| C    |# (define current-proxy-servers-promise
+#| C    |#   (make-parameter (delay/sync (env->c-p-s-entries '("plt_http_proxy" "http_proxy")))))
+
+#| C    |# (define (proxy-servers-guard v)
+#| C    |#   (unless (and (list? v)
+#| C    |#                (andmap (lambda (v)
+#| C    |#                          (and (list? v)
+#| C    |#                               (= 3 (length v))
+#| C    |#                               (equal? (car v) "http")
+#| C    |#                               (string? (car v))
+#| C    |#                               (exact-integer? (caddr v))
+#| C    |#                               (<= 1 (caddr v) 65535)))
+#| C    |#                        v))
+#| C    |#     (raise-type-error
+#| C    |#      'current-proxy-servers
+#| C    |#      "list of list of scheme, string, and exact integer in [1,65535]"
+#| C    |#      v))
+#| C    |#   (map (lambda (v)
+#| C    |#          (list (string->immutable-string (car v))
+#| C    |#                (string->immutable-string (cadr v))
+#| C    |#                (caddr v)))
+#| C    |#        v))
+
+#| C    |# (define current-proxy-servers
+#| C    |#   (make-derived-parameter current-proxy-servers-promise
+#| C    |#                           proxy-servers-guard
+#| C    |#                           force))
+
+#| C    |# (define (env->n-p-s-entries envars)
+#| C    |#   (if (null? envars)
+#| C    |#       null
+#| C    |#       (match (getenv (car envars))
+#| C    |#         [#f (env->n-p-s-entries (cdr envars))]
+#| C    |#         ["" null]
+#| C    |#         [hostnames (string-split hostnames ",")])))
+#| C    |#   
+#| C    |# (define current-no-proxy-servers-promise
+#| C    |#   (make-parameter (delay/sync (no-proxy-servers-guard (env->n-p-s-entries '("plt_no_proxy" "no_proxy"))))))
+
+#| C    |# (define (no-proxy-servers-guard v)
+#| C    |#   (unless (and (list? v)
+#| C    |#                (andmap (lambda (v)
+#| C    |#                          (or (string? v)
+#| C    |#                              (regexp? v)))
+#| C    |#                        v))
+#| C    |#     (raise-type-error 'current-no-proxy-servers
+#| C    |#                       "list of string or regexp"
+#| C    |#                       v))
+#| C    |#   (map (match-lambda
+#| C    |#          [(? regexp? re) re]
+#| C    |#          [(regexp "^(\\..*)$" (list _ m))
+#| C    |#           (regexp (string-append ".*" (regexp-quote m)))]
+#| C    |#          [(? string? s) (regexp (string-append "^"(regexp-quote s)"$"))])
+#| C    |#        v))
+
+#| C    |# (define current-no-proxy-servers
+#| C    |#   (make-derived-parameter current-no-proxy-servers-promise
+#| C    |#                           no-proxy-servers-guard
+#| C    |#                           force))
+
+#| C    |# (define (proxy-server-for url-schm (dest-host-name #f))
+#| C    |#   (let ((rv (assoc url-schm (current-proxy-servers))))
+#| C    |#     (cond [(not dest-host-name) rv]
+#| C    |#           [(memf (lambda (np) (regexp-match np dest-host-name)) (current-no-proxy-servers)) #f]
+#| C    |#           [else rv])))
+
+#| C    |# (define (url-error fmt . args)
+#| C    |#   (raise (make-url-exception
+#| C    |#           (apply format fmt
+#| C    |#                  (map (lambda (arg) (if (url? arg) (url->string arg) arg))
+#| C    |#                       args))
+#| C    |#           (current-continuation-marks))))
+
+#| C    |# ;; url->default-port : url -> num
+#| C    |# (define (url->default-port url)
+#| C    |#   (let ([scheme (url-scheme url)])
+#| C    |#     (cond [(not scheme) 80]
+#| C    |#           [(string=? scheme "http") 80]
+#| C    |#           [(string=? scheme "https") 443]
+#| C    |#           [(string=? scheme "git") 9418]
+#| C    |#           [else (url-error "URL scheme ~s not supported" scheme)])))
+
+#| C    |# ;; make-ports : url -> hc
+#| C    |# (define (make-ports url proxy)
+#| C    |#   (let ([port-number (if proxy
+#| C    |#                        (caddr proxy)
+#| C    |#                        (or (url-port url) (url->default-port url)))]
+#| C    |#         [host (if proxy (cadr proxy) (url-host url))])
+#| C    |#     (hc:http-conn-open host
+#| C    |#                        #:port port-number
+#| C    |#                        #:ssl? (if (equal? "https" (url-scheme url))
+#| C    |#                                 (current-https-protocol)
+#| C    |#                                 #f))))
+
+#| C    |# ;; http://getpost-impure-port : bool x url x union (str, #f) x list (str)
+#| C    |# ;;                               -> hc
+#| C    |# (define (http://getpost-impure-port get? url post-data strings
+#| C    |#                                     make-ports 1.1?)
+#| C    |#   (define proxy (proxy-server-for (url-scheme url) (url-host url)))
+#| C    |#   (define hc (make-ports url proxy))
+#| C    |#   (define access-string
+#| C    |#     (ensure-non-empty
+#| C    |#      (url->string
+#| C    |#       (if proxy
+#| C    |#           url
+#| C    |#           ;; RFCs 1945 and 2616 say:
+#| C    |#           ;;   Note that the absolute path cannot be empty; if none is present in
+#| C    |#           ;;   the original URI, it must be given as "/" (the server root).
+#| C    |#           (let-values ([(abs? path)
+#| C    |#                         (if (null? (url-path url))
+#| C    |#                             (values #t (list (make-path/param "" '())))
+#| C    |#                             (values (url-path-absolute? url) (url-path url)))])
+#| C    |#             (make-url #f #f #f #f abs? path (url-query url) (url-fragment url)))))))
+
+#| C    |#   (hc:http-conn-send! hc access-string
+#| C    |#                       #:method (if get? #"GET" #"POST")
+#| C    |#                       #:headers strings
+#| C    |#                       #:content-decode '()
+#| C    |#                       #:data post-data)
+#| C    |#   hc)
+
+#| C    |# ;; file://get-pure-port : url -> in-port
+#| C    |# (define (file://get-pure-port url)
+#| C    |#   (open-input-file (file://->path url)))
+
+#| C    |# (define (schemeless-url url)
+#| C    |#   (url-error "Missing protocol (usually \"http:\") at the beginning of URL: ~a" url))
+
+#| C    |# ;; getpost-impure-port : bool x url x list (str) -> in-port
+#| C    |# (define (getpost-impure-port get? url post-data strings)
+#| C    |#   (let ([scheme (url-scheme url)])
+#| C    |#     (cond [(not scheme)
+#| C    |#            (schemeless-url url)]
+#| C    |#           [(or (string=? scheme "http") (string=? scheme "https"))
+#| C    |#            (define hc
+#| C    |#              (http://getpost-impure-port get? url post-data strings make-ports #f))
+#| C    |#            (http-conn-impure-port hc
+#| C    |#                                   #:method (if get? "GET" "POST"))]
+#| C    |#           [(string=? scheme "file")
+#| C    |#            (url-error "There are no impure file: ports")]
+#| C    |#           [else (url-error "Scheme ~a unsupported" scheme)])))
+
+#| C    |# (define (http-conn-impure-port hc
+#| C    |#                                #:method [method-bss #"GET"])
+#| C    |#   (define-values (in out) (make-pipe 4096))
+#| C    |#   (define-values (status headers response-port)
+#| C    |#     (hc:http-conn-recv! hc #:method method-bss #:close? #t #:content-decode '()))
+#| C    |#   (fprintf out "~a\r\n" status)
+#| C    |#   (for ([h (in-list headers)])
+#| C    |#     (fprintf out "~a\r\n" h))
+#| C    |#   (fprintf out "\r\n")
+#| C    |#   (thread
+#| C    |#    (λ ()
+#| C    |#      (copy-port response-port out)
+#| C    |#      (close-output-port out)))
+#| C    |#   in)
+
+#| C    |# ;; get-impure-port : url [x list (str)] -> in-port
+#| C    |# (define (get-impure-port url [strings '()])
+#| C    |#   (getpost-impure-port #t url #f strings))
+
+#| C    |# ;; post-impure-port : url x bytes [x list (str)] -> in-port
+#| C    |# (define (post-impure-port url post-data [strings '()])
+#| C    |#   (getpost-impure-port #f url post-data strings))
+
+#| C    |# ;; getpost-pure-port : bool x url x list (str) -> in-port
+#| C    |# (define (getpost-pure-port get? url post-data strings redirections)
+#| C    |#   (let ([scheme (url-scheme url)])
+#| C    |#     (cond [(not scheme)
+#| C    |#            (schemeless-url url)]
+#| C    |#           [(or (string=? scheme "http")
+#| C    |#                (string=? scheme "https"))
+#| C    |#            (cond
+#| C    |#              [(or (not get?)
+#| C    |#                   ;; do not follow redirections for POST
+#| C    |#                   (zero? redirections))
+#| C    |#               (define-values (status headers response-port)
+#| C    |#                 (hc:http-conn-recv!
+#| C    |#                  (http://getpost-impure-port
+#| C    |#                   get? url post-data strings
+#| C    |#                   make-ports #f)
+#| C    |#                  #:method (if get? #"GET" #"POST")
+#| C    |#                  #:content-decode '()
+#| C    |#                  #:close? #t))
+#| C    |#               response-port]
+#| C    |#              [else
+#| C    |#               (define-values (port header)
+#| C    |#                 (get-pure-port/headers url strings #:redirections redirections))
+#| C    |#               port])]
+#| C    |#           [(string=? scheme "file")
+#| C    |#            (file://get-pure-port url)]
+#| C    |#           [else (url-error "Scheme ~a unsupported" scheme)])))
+
+#| C    |# (define (make-http-connection)
+#| C    |#   (hc:http-conn))
+
+#| C    |# (define (http-connection-close hc)
+#| C    |#   (hc:http-conn-close! hc))
+
+#| C    |# (define (get-pure-port/headers url [strings '()]
+#| C    |#                                #:redirections [redirections 0]
+#| C    |#                                #:status? [status? #f]
+#| C    |#                                #:connection [conn #f])
+#| C    |#   (let redirection-loop ([redirections redirections] [url url] [use-conn conn])
+#| C    |#     (define hc
+#| C    |#       (http://getpost-impure-port #t url #f strings
+#| C    |#                                   (if (and use-conn
+#| C    |#                                            (hc:http-conn-live? use-conn))
+#| C    |#                                     (lambda (url proxy)
+#| C    |#                                       (log-net/url-debug "reusing connection")
+#| C    |#                                       use-conn)
+#| C    |#                                     make-ports)
+#| C    |#                                   (and conn #t)))
+#| C    |#     (define-values (status headers response-port)
+#| C    |#       (hc:http-conn-recv! hc #:method #"GET" #:close? (not conn) #:content-decode '()))
+
+#| C    |#     (define new-url
+#| C    |#       (ormap (λ (h)
+#| C    |#                (match (regexp-match #rx#"^Location: (.*)$" h)
+#| C    |#                  [#f #f]
+#| C    |#                  [(list _ m1b)
+#| C    |#                   (define m1 (bytes->string/utf-8 m1b))
+#| C    |#                   (with-handlers ((exn:fail? (λ (x) #f)))
+#| C    |#                     (define next-url (string->url m1))
+#| C    |#                     (make-url
+#| C    |#                      (or (url-scheme next-url) (url-scheme url))
+#| C    |#                      (or (url-user next-url) (url-user url))
+#| C    |#                      (or (url-host next-url) (url-host url))
+#| C    |#                      (or (url-port next-url) (url-port url))
+#| C    |#                      (url-path-absolute? next-url)
+#| C    |#                      (url-path next-url)
+#| C    |#                      (url-query next-url)
+#| C    |#                      (url-fragment next-url)))]))
+#| C    |#              headers))
+#| C    |#     (define redirection-status-line?
+#| C    |#       (regexp-match #rx#"^HTTP/[0-9]+[.][0-9]+ 3[0-9][0-9]" status))
+#| C    |#     (cond
+#| C    |#       [(and redirection-status-line? new-url (not (zero? redirections)))
+#| C    |#        (log-net/url-info "redirection: ~a" (url->string new-url))
+#| C    |#        (redirection-loop (- redirections 1) new-url #f)]
+#| C    |#       [else
+#| C    |#        (values response-port
+#| C    |#                (apply string-append
+#| C    |#                       (map (λ (x) (format "~a\r\n" x))
+#| C    |#                            (if status?
+#| C    |#                              (cons status headers)
+#| C    |#                              headers))))])))
+
+#| C    |# ;; get-pure-port : url [x list (str)] -> in-port
+#| C    |# (define (get-pure-port url [strings '()] #:redirections [redirections 0])
+#| C    |#   (getpost-pure-port #t url #f strings redirections))
+
+#| C    |# ;; post-pure-port : url bytes [x list (str)] -> in-port
+#| C    |# (define (post-pure-port url post-data [strings '()])
+#| C    |#   (getpost-pure-port #f url post-data strings 0))
+
+#| C    |# ;; display-pure-port : in-port -> ()
+#| C    |# (define (display-pure-port server->client)
+#| C    |#   (copy-port server->client (current-output-port))
+#| C    |#   (close-input-port server->client))
+
+#| C    |# ;; call/input-url : url x (url -> in-port) x (in-port -> T)
+#| C    |# ;;                  [x list (str)] -> T
+#| C    |# (define call/input-url
+#| C    |#   (let ([handle-port
+#| C    |#          (lambda (server->client handler)
+#| C    |#            (dynamic-wind (lambda () 'do-nothing)
+#| C    |#                (lambda () (handler server->client))
+#| C    |#                (lambda () (close-input-port server->client))))])
+#| C    |#     (case-lambda
+#| C    |#       [(url getter handler)
+#| C    |#        (handle-port (getter url) handler)]
+#| C    |#       [(url getter handler params)
+#| C    |#        (handle-port (getter url params) handler)])))
+
+#| C    |# ;; purify-port : in-port -> header-string
+#| C    |# (define (purify-port port)
+#| C    |#   (let ([m (regexp-match-peek-positions
+#| C    |#             #rx"^HTTP/.*?(?:\r\n\r\n|\n\n|\r\r)" port)])
+#| C    |#     (if m (read-string (cdar m) port) "")))
+
+#| C    |# ;; purify-http-port : in-port -> in-port
+#| C    |# (define (purify-http-port in-port)
+#| C    |#   (purify-port in-port)
+#| C    |#   in-port)
+
+#| C    |# ;; delete-pure-port : url [x list (str)] -> in-port
+#| C    |# (define (delete-pure-port url [strings '()])
+#| C    |#   (method-pure-port 'delete url #f strings))
+
+#| C    |# ;; delete-impure-port : url [x list (str)] -> in-port
+#| C    |# (define (delete-impure-port url [strings '()])
+#| C    |#   (method-impure-port 'delete url #f strings))
+
+#| C    |# ;; head-pure-port : url [x list (str)] -> in-port
+#| C    |# (define (head-pure-port url [strings '()])
+#| C    |#   (method-pure-port 'head url #f strings))
+
+#| C    |# ;; head-impure-port : url [x list (str)] -> in-port
+#| C    |# (define (head-impure-port url [strings '()])
+#| C    |#   (method-impure-port 'head url #f strings))
+
+#| C    |# ;; put-pure-port : url bytes [x list (str)] -> in-port
+#| C    |# (define (put-pure-port url put-data [strings '()])
+#| C    |#   (method-pure-port 'put url put-data strings))
+
+#| C    |# ;; put-impure-port : url x bytes [x list (str)] -> in-port
+#| C    |# (define (put-impure-port url put-data [strings '()])
+#| C    |#   (method-impure-port 'put url put-data strings))
+
+#| C    |# ;; options-pure-port : url [x list (str)] -> in-port
+#| C    |# (define (options-pure-port url [strings '()])
+#| C    |#   (method-pure-port 'options url #f strings))
+
+#| C    |# ;; options-impure-port : url [x list (str)] -> in-port
+#| C    |# (define (options-impure-port url [strings '()])
+#| C    |#   (method-impure-port 'options url #f strings))
+
+#| C    |# ;; method-impure-port : symbol x url x list (str) -> in-port
+#| C    |# (define (method-impure-port method url data strings)
+#| C    |#   (let ([scheme (url-scheme url)])
+#| C    |#     (cond [(not scheme)
+#| C    |#            (schemeless-url url)]
+#| C    |#           [(or (string=? scheme "http") (string=? scheme "https"))
+#| C    |#            (http://method-impure-port method url data strings)]
+#| C    |#           [(string=? scheme "file")
+#| C    |#            (url-error "There are no impure file: ports")]
+#| C    |#           [else (url-error "Scheme ~a unsupported" scheme)])))
+
+#| C    |# ;; method-pure-port : symbol x url x list (str) -> in-port
+#| C    |# (define (method-pure-port method url data strings)
+#| C    |#   (let ([scheme (url-scheme url)])
+#| C    |#     (cond [(not scheme)
+#| C    |#            (schemeless-url url)]
+#| C    |#           [(or (string=? scheme "http") (string=? scheme "https"))
+#| C    |#            (let ([port (http://method-impure-port
+#| C    |#                         method url data strings)])
+#| C    |#              (purify-http-port port))]
+#| C    |#           [(string=? scheme "file")
+#| C    |#            (file://get-pure-port url)]
+#| C    |#           [else (url-error "Scheme ~a unsupported" scheme)])))
+
+#| C    |# ;; http://metod-impure-port : symbol x url x union (str, #f) x list (str) -> in-port
+#| C    |# (define (http://method-impure-port method url data strings)
+#| C    |#   (let* ([method (case method
+#| C    |#                    [(get) "GET"] [(post) "POST"] [(head) "HEAD"]
+#| C    |#                    [(put) "PUT"] [(delete) "DELETE"] [(options) "OPTIONS"] 
+#| C    |#                    [else (url-error "unsupported method: ~a" method)])]
+#| C    |#          [proxy (proxy-server-for (url-scheme url) (url-host url))]
+#| C    |#          [hc (make-ports url proxy)]
+#| C    |#          [access-string
+#| C    |#           (ensure-non-empty
+#| C    |#            (url->string
+#| C    |#             (if proxy
+#| C    |#                 url
+#| C    |#                 (make-url #f #f #f #f
+#| C    |#                           (url-path-absolute? url)
+#| C    |#                           (url-path url)
+#| C    |#                           (url-query url)
+#| C    |#                           (url-fragment url)))))])
+#| C    |#     (hc:http-conn-send! hc access-string
+#| C    |#                         #:method method
+#| C    |#                         #:headers strings
+#| C    |#                         #:content-decode '()
+#| C    |#                         #:data data)
+#| C    |#     (http-conn-impure-port hc
+#| C    |#                            #:method method)))
+
+#| C    |# (define (ensure-non-empty s)
+#| C    |#   (if (string=? "" s)
+#| C    |#       "/"
+#| C    |#       s))
+
+#| C    |# ;(provide (all-from-out "url-string.rkt"))
+
+#| C  R |# (provide/contract
+#| C  R |#  (get-pure-port (->* (url?) ((listof string?) #:redirections exact-nonnegative-integer?) input-port?))
+#| C  R |#  (get-impure-port (->* (url?) ((listof string?)) input-port?))
+#| C  R |#  (post-pure-port (->* (url? (or/c false/c bytes?)) ((listof string?)) input-port?))
+#| C  R |#  (post-impure-port (->* (url? bytes?) ((listof string?)) input-port?))
+#| C  R |#  (head-pure-port (->* (url?) ((listof string?)) input-port?))
+#| C  R |#  (head-impure-port (->* (url?) ((listof string?)) input-port?))
+#| C  R |#  (delete-pure-port (->* (url?) ((listof string?)) input-port?))
+#| C  R |#  (delete-impure-port (->* (url?) ((listof string?)) input-port?))
+#| C  R |#  (put-pure-port (->* (url? (or/c false/c bytes?)) ((listof string?)) input-port?))
+#| C  R |#  (put-impure-port (->* (url? bytes?) ((listof string?)) input-port?))
+#| C  R |#  (options-pure-port (->* (url?) ((listof string?)) input-port?))
+#| C  R |#  (options-impure-port (->* (url?) ((listof string?)) input-port?))
+#| C  R |#  (display-pure-port (input-port? . -> . void?))
+#| C  R |#  (purify-port (input-port? . -> . string?))
+#| C  R |#  (get-pure-port/headers (->* (url?)
+#| C  R |#                              ((listof string?)
+#| C    |#                               #:redirections exact-nonnegative-integer?
+#| C    |#                               #:status? boolean?
+#| C  R |#                               #:connection (or/c #f hc:http-conn?))
+#| C    |#                              (values input-port? string?)))
+#| C  R |#  (rename hc:http-conn? http-connection? (any/c . -> . boolean?))
+#| C  R |#  (make-http-connection (-> hc:http-conn?))
+#| C  R |#  (http-connection-close (hc:http-conn? . -> . void?))
+#| C  R |#  (call/input-url (case-> (-> url?
+#| C  R |#                              (-> url? input-port?)
+#| C  R |#                              (-> input-port? any)
+#| C  R |#                              any)
+#| C  R |#                          (-> url?
+#| C  R |#                              (-> url? (listof string?) input-port?)
+#| C  R |#                              (-> input-port? any)
+#| C  R |#                              (listof string?)
+#| C  R |#                              any)))
+#| C    |#  (current-proxy-servers
+#| C  R |#   (parameter/c (or/c false/c (listof (list/c string? string? number?)))))
+#| C    |#  (current-no-proxy-servers
+#| C  R |#   (parameter/c (or/c false/c (listof (or/c string? regexp?)))))
+#| C  R |#  (proxy-server-for (->* (string?) ((or/c false/c string?))
+#| C  R |#                         (or/c false/c (list/c string? string? number?))))
+#| C  R |#  (proxiable-url-schemes (listof string?)))
+
+#| C    |# (define (http-sendrecv/url u
+#| C    |#                            #:method [method-bss #"GET"]
+#| C    |#                            #:headers [headers-bs empty]
+#| C    |#                            #:data [data #f]
+#| C    |#                            #:content-decode [decodes '(gzip)])
+#| C    |#   (unless (member (url-scheme u) '(#f "http" "https"))
+#| C    |#     (error 'http-sendrecv/url "URL scheme ~e not supported" (url-scheme u)))
+#| C    |#   (define ssl?
+#| C    |#     (equal? (url-scheme u) "https"))
+#| C    |#   (define port
+#| C    |#     (or (url-port u)
+#| C    |#         (if ssl?
+#| C    |#           443
+#| C    |#           80)))
+#| C    |#   (unless (url-host u)
+#| C    |#     (error 'http-sendrecv/url "Host required: ~e" u))
+#| C    |#   (hc:http-sendrecv
+#| C    |#    (url-host u)
+#| C    |#    (ensure-non-empty
+#| C    |#     (url->string
+#| C    |#      (make-url #f #f #f #f
+#| C    |#                (url-path-absolute? u)
+#| C    |#                (url-path u)
+#| C    |#                (url-query u)
+#| C    |#                (url-fragment u))))
+#| C    |#    #:ssl?
+#| C    |#    (if (equal? "https" (url-scheme u))
+#| C    |#      (current-https-protocol)
+#| C    |#      #f)
+#| C    |#    #:port port
+#| C    |#    #:method method-bss
+#| C    |#    #:headers headers-bs
+#| C    |#    #:data data
+#| C    |#    #:content-decode decodes))
+
+#| C    |# (provide
+#| C  R |#  (contract-out
+#| C    |#   [http-sendrecv/url
+#| C  R |#    (->* (url?)
+#| C  R |#         (#:method (or/c bytes? string? symbol?)
+#| C  R |#                   #:headers (listof (or/c bytes? string?))
+#| C  R |#                   #:data (or/c false/c bytes? string? hc:data-procedure/c)
+#| C  R |#                   #:content-decode (listof symbol?))
+#| C  R |#         (values bytes? (listof bytes?) input-port?))]))

--- a/test/data/typed-racket/small-type-ann.rkt
+++ b/test/data/typed-racket/small-type-ann.rkt
@@ -1,0 +1,9 @@
+#lang typed/racket/base
+
+#|  T   |# (: a Integer)
+#| C    |# (define a 4)
+
+#|  T   |# (: b (-> Integer Integer))
+#| C    |# (define (b x)
+#| C    |#   x)
+

--- a/test/data/typed-racket/type-ann.rkt
+++ b/test/data/typed-racket/type-ann.rkt
@@ -1,0 +1,42 @@
+#lang typed/racket/base
+
+;; This is a file with some code (C)
+;; and some type annotations (T)
+;; and some contracts (R)
+
+#|  T   |# (: a Integer)
+#| C    |# (define a 4)
+
+#|  T   |# (: b (-> Integer Integer))
+#| C    |# (define (b n)
+#| C    |#   n)
+
+#| CT   |# (define (c (x : String) (y : String)) : String
+#| CT   |#   ((lambda ((z : String)) z) "hello"))
+
+#| CT   |# (let* ([d : Integer 8]
+#| C    |#        [e (for/fold :
+#|  T   |#                     (Listof
+#|      |#                       (
+#|  T   |#                        Listof
+#|  T   |#                         (Listof Integer)))
+#| CT   |#                     ([acc : (Listof (Listof (Listof Integer))) '((()))])
+#| C    |#                     ([e (in-range d)])
+#| C    |#                  acc)])
+#| C    |#   (void))
+
+#| C    |# (module ctc racket/base
+#| C    |#   (require racket/contract)
+#| C    |#   (define (f x y)
+#| C    |#     (+ x y 1))
+#| C    |#   (provide
+#| C  R |#     (contract-out
+#| C  R |#       [f (->i ([x natural-number/c]
+#|    R |#                [y (x) (>=/c x)])
+#|    R |#               [result (x y) (and/c number? (>=/c (+ x y)))])])))
+
+#| C    |# (module* untyped racket/base
+#| C    |#   (define Symbol 2)
+#| C    |#   (define (-> x y)
+#| C    |#     (+ x y 1))
+#| C    |#   (-> (-> Symbol Symbol) Symbol))

--- a/test/predicates.rkt
+++ b/test/predicates.rkt
@@ -42,7 +42,7 @@
   (for ([tag+p (in-list predicates)]) : Void
     (define-values (tag p) (apply values tag+p))
     (define handwritten-sloc (count-tagged-lines (car tag+p) path))
-    (define automatic-sloc (lang-file-sloc path #:use-stx? p))
+    (define automatic-sloc (lang-file-sloc path #:include-stx? p))
     (check-equal? automatic-sloc handwritten-sloc
                   (format "~a lines of code in '~a'" tag path))))
 

--- a/test/predicates.rkt
+++ b/test/predicates.rkt
@@ -1,0 +1,80 @@
+#lang typed/racket/base (module+ test
+
+;; End-to-end unit tests for [syntax-sloc with predicates]
+;;
+;; Parses whole `.rkt` files for their line counts
+;;  and compares the automated result to hand-written annotations in the files.
+
+(require typed/rackunit
+         racket/runtime-path
+         syntax/parse/define
+         syntax-sloc/lang-file-sloc
+         syntax-sloc/syntax-predicates
+         (only-in racket/string string-contains?)
+         (only-in syntax-sloc/syntax-sloc Stx-Pred)
+         (for-syntax racket/base))
+
+;; IMPORTANT: if you expect a predicate in this list
+;;   to count a certain line from a new test file,
+;;   annotate that line with
+;;     #| TAG |#
+;;   where `TAG` is the symbol next to your predicate in the list `predicates`.
+;;
+;;  For example, every line of Typed Racket type annotation, like:
+;;    (: foo (-> Integer Integer))
+;;  should be annotated as:
+;;    #| T |# (: foo (-> Integer Integer))
+;;  to tell the unit tester "if the `is-type-ann?` predicate doesn't recognize
+;;  this line, we have a problem!"
+(: predicates : (Listof (List Symbol Stx-Pred)))
+
+(define predicates `(
+  ;TODO;(T ,is-type-ann?)
+  (R ,is-contract?)
+))
+
+;; -----------------------------------------------------------------------------
+
+;; For each predicate, compare the hand-annotated count of relevant lines
+;;  to the number of lines accepted by the predicate.
+(: check-sloc/predicates : Path-String -> Void)
+(define (check-sloc/predicates path)
+  (for ([tag+p (in-list predicates)]) : Void
+    (define-values (tag p) (apply values tag+p))
+    (define handwritten-sloc (count-tagged-lines (car tag+p) path))
+    (define automatic-sloc (lang-file-sloc path #:use-stx? p))
+    (check-equal? automatic-sloc handwritten-sloc
+                  (format "~a lines of code in '~a'" tag path))))
+
+;; Count the number of hand-annotated lines in a file.
+(: count-tagged-lines : Symbol Path-String -> Natural)
+(define (count-tagged-lines tag-sym path)
+  (define tag-str (symbol->string tag-sym))
+  (define tags-rx
+    (pregexp (string-append "^(\\s)?#\\|(.+)\\|#\\s")))
+  (with-input-from-file path
+    (lambda ()
+      (for/sum : Natural
+                ([ln (in-lines)])
+        (define m (regexp-match tags-rx ln))
+        (if (and m (string-contains? (or (caddr m) (error 'rx)) tag-str))
+          1
+          0)))))
+
+;; -----------------------------------------------------------------------------
+
+(define-simple-macro (define-sloc-test-file path* ...)
+  #:with (id* ...) (for/list ([_p (in-list (syntax-e #'(path* ...)))]) (gensym 'path))
+  (begin (begin (define-runtime-path id* path*) (check-sloc/predicates id*)) ...))
+
+(define-sloc-test-file
+  "data/contract/simple.rkt"
+  "data/contract/redefine.rkt"
+  "data/contract/rename-in.rkt"
+  "data/contract/submodule.rkt"
+  "data/contract/url.rkt")
+
+(define-sloc-test-file
+  "data/typed-racket/small-type-ann.rkt"
+  "data/typed-racket/type-ann.rkt")
+)

--- a/typed/syntax-sloc/read-lang-file.rkt
+++ b/typed/syntax-sloc/read-lang-file.rkt
@@ -1,10 +1,11 @@
 #lang typed/racket/base
 
-(provide read-lang-file lang-file?)
+(provide read-lang-file lang-file? lang-file-lang)
 
 (require typed/racket/unsafe)
 
 (unsafe-require/typed syntax-sloc/read-lang-file
                       [read-lang-file (-> Path-String (Syntaxof Any))]
-                      [lang-file? (-> Path-String Boolean)])
+                      [lang-file? (-> Path-String Boolean)]
+                      [lang-file-lang (-> Path-String String)])
 


### PR DESCRIPTION
Checking in, but this is not accurate enough to merge.

Goal (address #4 ):
- `raco sloc -m racket/contract file.rkt` counts only lines that use identifiers from `racket/contract`
- `raco sloc -m "(racket/string racket/format)" file.rkt` only counts lines from `racket/string` or `racket/format`
- `raco sloc -m type-ann file.rkt` counts only lines that contain a "type" -- where a type is an identifier exported from a pre-defined list of modules

This sort of works:

```
#lang racket ;; test.rkt
(provide (contract-out [x natural-number/c]))
(define x 0)
```

```
> raco sloc -m racket/contract test.rkt
SLOC(racket/contract)   Source
   1    c.rkt
```

but adding a `prefix-in` brings the line count to 0.

Possibly related, counting does not work at all for `typed/racket` or even `typed-racket/base-env/base-types`.

On the agenda:
- try re-implementing with `module->namespace` instead of using `racket/contract` etc directly to make identifiers
